### PR TITLE
Change phi offset from 2 to 1 in Calo Region calculations

### DIFF
--- a/converters/root_to_h5.py
+++ b/converters/root_to_h5.py
@@ -35,7 +35,7 @@ class DataSource:
             eta, phi, et, em = eta[mask], phi[mask], et[mask], em[mask]
             eta = ak.where(eta < 0, eta, eta - 1)
             eta = eta + 28
-            phi = (phi + 2) % 72
+            phi = (phi + 1) % 72
 
             ids = np.arange(len(eta))
             self.ids = ak.flatten(ak.broadcast_arrays(ids, eta)[0])

--- a/converters/root_to_h5_one_file.py
+++ b/converters/root_to_h5_one_file.py
@@ -35,7 +35,7 @@ class DataSource:
             eta, phi, et, em = eta[mask], phi[mask], et[mask], em[mask]
             eta = ak.where(eta < 0, eta, eta - 1)
             eta = eta + 28
-            phi = (phi + 2) % 72
+            phi = (phi + 1) % 72
 
             ids = np.arange(len(eta))
             self.ids = ak.flatten(ak.broadcast_arrays(ids, eta)[0])


### PR DESCRIPTION
I think the phi offset here is wrong:

https://github.com/AdrianAlan/L1CaloTriggerAD/blob/ef7eff99ceeba5e727ff2f4d64033f98b98620b1/converters/root_to_h5.py#L38

The intention here is to shift iPhi 71 and 72 up two indices so that you include them in the regions with iPhi 1 and iPhi 2, however this takes iPhi 71 to  71+2 = 73 and 73 % 72 = 1 which maps iPhi 71 to index 1 in the tenor. 

Unless I am mistaken, this is one too high, as you want this to be the new index 0 in the tensor. Doing it in this way will map iPhi 70 to 70+2 = 72 and 72%72 = 0, including it in a region with iPhi 71, iPhi 72, and iPhi 1 when you do the block reduction.

This maps iPhi 71 to index 0, iPhi 72 to index 1, iPhi 1 to index 2, and iPhi 2 to index 3, which includes them all in the same region (GCT phi 0 in the link map image), and shifts everything else up 1
